### PR TITLE
feat: add verify_system to work correctly on window and linux

### DIFF
--- a/config/telegram-git-notifier.php
+++ b/config/telegram-git-notifier.php
@@ -21,7 +21,7 @@ return [
 
         /* Required for the bot to work properly */
         'url' => env('TGN_APP_URL', env('APP_URL', 'http://localhost')).'/'.$routePrefix,
-        'verify_system' => env('VERIFY_SYSTEM', 'true'),
+        'request_verify' => env('TGN_REQUEST_VERIFY', 'true'),
     ],
 
     'bot' => [

--- a/config/telegram-git-notifier.php
+++ b/config/telegram-git-notifier.php
@@ -21,6 +21,7 @@ return [
 
         /* Required for the bot to work properly */
         'url' => env('TGN_APP_URL', env('APP_URL', 'http://localhost')).'/'.$routePrefix,
+        'verify_system' => env('VERIFY_SYSTEM', 'true'),
     ],
 
     'bot' => [

--- a/config/telegram-git-notifier.php
+++ b/config/telegram-git-notifier.php
@@ -21,7 +21,7 @@ return [
 
         /* Required for the bot to work properly */
         'url' => env('TGN_APP_URL', env('APP_URL', 'http://localhost')).'/'.$routePrefix,
-        'request_verify' => env('TGN_REQUEST_VERIFY', 'true'),
+        'request_verify' => env('TGN_REQUEST_VERIFY', false),
     ],
 
     'bot' => [


### PR DESCRIPTION
On window, if you use `'verify' => true` in options of the client request, the system will not work correctly. Add an environment variable to allow user can modify status `verify` to fit each OS.